### PR TITLE
Don't auto scale down input tasks with non running input gates.

### DIFF
--- a/nephele/nephele-server/src/main/java/eu/stratosphere/nephele/execution/RuntimeEnvironment.java
+++ b/nephele/nephele-server/src/main/java/eu/stratosphere/nephele/execution/RuntimeEnvironment.java
@@ -391,8 +391,11 @@ public class RuntimeEnvironment implements Environment, Runnable {
 			// FIXME: Handle more than one input gate (wait for DRAINNING gates)
 
 			// suspend this task if all input gates already suspended
-			if (countSuspendedInputGates() == this.inputGates.size() && !this.executionObserver.isSuspending()) {
-				LOG.warn("SUspending task, because of no running input gates available");
+			if (this.inputGates.size() > 0
+					&& countSuspendedInputGates() == this.inputGates.size()
+					&& !this.executionObserver.isSuspending()) {
+
+				LOG.warn("All input gates are suspended. Supending this task too.");
 				changeExecutionState(ExecutionState.SUSPENDING, null);
 			}
 


### PR DESCRIPTION
This prevents automatic scale downs on input tasks.
