### PR TITLE
Suspend more than one input gate support added.

### DIFF
--- a/nephele/nephele-server/src/main/java/eu/stratosphere/nephele/taskmanager/runtime/RuntimeTask.java
+++ b/nephele/nephele-server/src/main/java/eu/stratosphere/nephele/taskmanager/runtime/RuntimeTask.java
@@ -403,9 +403,9 @@ public final class RuntimeTask implements Task, ExecutionObserver {
 				invokable.suspend();
 			}
 
-			// FIXME: suspension currently only works for tasks with a single
-			// input gate
-			this.environment.getInputGate(0).requestSuspend();
+			for (int gate = 0; gate < this.environment.getNumberOfInputGates(); gate++) {
+				this.environment.getInputGate(gate).requestSuspend();
+			}
 		} catch (Throwable e) {
 			LOG.error(StringUtils.stringifyException(e));
 		}


### PR DESCRIPTION
Testet with twitter-sentiment (two bipartit inputs) and two input/ouput pairwise connected vertices test job.

This resolves #17 
