### PR TITLE
Fix scale down in auto scaler (use a positiv number of tasks).

### DIFF
--- a/nephele/nephele-server/src/main/java/eu/stratosphere/nephele/jobmanager/JobManager.java
+++ b/nephele/nephele-server/src/main/java/eu/stratosphere/nephele/jobmanager/JobManager.java
@@ -1426,8 +1426,8 @@ public class JobManager implements DeploymentManager, ExtendedManagementProtocol
 		this.scheduler.scaleUpElasticTask(jobID, jobVertexID, noOfSubtasksToStart);
 	}
 
-	public void scaleDownElasticTask(JobID jobID, JobVertexID jobVertexID, final int noOfSubtasksToStart) throws Exception {
-		this.scheduler.scaleDownElasticTask(jobID, jobVertexID, noOfSubtasksToStart);
+	public void scaleDownElasticTask(JobID jobID, JobVertexID jobVertexID, final int noOfSubtasksToSuspend) throws Exception {
+		this.scheduler.scaleDownElasticTask(jobID, jobVertexID, noOfSubtasksToSuspend);
 	}
 
 	public ExecutionGroupVertex getExecutionGroupVertex(JobID jobID, JobVertexID jobVertexID) {

--- a/nephele/nephele-streaming/src/main/java/eu/stratosphere/nephele/streaming/jobmanager/autoscaling/ElasticTaskQosAutoScalingThread.java
+++ b/nephele/nephele-streaming/src/main/java/eu/stratosphere/nephele/streaming/jobmanager/autoscaling/ElasticTaskQosAutoScalingThread.java
@@ -251,7 +251,7 @@ public class ElasticTaskQosAutoScalingThread extends Thread {
 						int scalingAction = scalingActions.get(vertexId);
 						if (scalingAction < 0) {
 							jm.scaleDownElasticTask(jobID, vertexId,
-									scalingAction);
+									- scalingAction);
 
 						}
 					}

--- a/nephele/nephele-streaming/src/main/java/eu/stratosphere/nephele/streaming/jobmanager/autoscaling/SimpleScalingPolicy.java
+++ b/nephele/nephele-streaming/src/main/java/eu/stratosphere/nephele/streaming/jobmanager/autoscaling/SimpleScalingPolicy.java
@@ -58,7 +58,7 @@ public class SimpleScalingPolicy extends AbstractScalingPolicy {
 				rebalance(constraint, constraintSummary, scalingActions, false);
 			}
 		} else {
-			rebalance(constraint, constraintSummary, scalingActions, false);
+			rebalance(constraint, constraintSummary, scalingActions, true);
 		}
 		
 		LOG.debug(String.format("%d %s", QosUtils.alignToInterval(


### PR DESCRIPTION
This pull-request fixes a copy&paste failure... The parameter naming at scaleDownElasticTask was somehow confusing. The number of subtasks has to be a positiv value!

At this point there is another bug:
The simple scaling policy / rebalancer works on tasks. The AbstractSceduler scaleDown method works on scaling paths! Calling scaleDown on all nodes on path results in multiple scale downs.
